### PR TITLE
Fix readme.md register extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ After that you have to register extension in config.neon.
 
 ```neon
 extensions:
+	webSockets: IPub\WebSockets\DI\WebSocketsExtension
 	webSocketsWAMP: IPub\WebSocketsWAMP\DI\WebSocketsWAMPExtension
 ```
 


### PR DESCRIPTION
Je potřeba zaregistrovat ještě IPub\WebSockets\DI\WebSocketsExtension jinak to hlásí 'IPub\WebSockets\Server\Server' not found.